### PR TITLE
Add organization default security community health file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,7 @@
 The [Cytomining](https://github.com/cytomining) maintainers and community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
 To report a security issue, please use the GitHub Security Advisory __"Report a Vulnerability" tab__ within the related a related project.
+If you don't find the relevant project link below, please select one from the below and specify in the form fields to which project the issue pertains.
 
 - [__Pycytominer__ Vulnerability Report Form](https://github.com/cytomining/pycytominer/security/advisories/new)
 - [__CytoTable__ Vulnerability Report Form](https://github.com/cytomining/cytotable/security/advisories/new)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Reporting Security Issues
+
+The [Cytomining](https://github.com/cytomining) maintainers and community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory __"Report a Vulnerability" tab__ within the related a related project.
+
+- [__Pycytominer__ Vulnerability Report Form](https://github.com/cytomining/pycytominer/security/advisories/new)
+- [__CytoTable__ Vulnerability Report Form](https://github.com/cytomining/cytotable/security/advisories/new)
+
+## Using "Development" vs "Non-development" Dependencies
+
+A number of development-only dependencies are included with Cytomining projects for maintenance and testing purposes.
+Please see, for example, project `pyproject.toml` table `[tool.poetry.dependencies]` for a list of non-development dependencies and `[tool.poetry.group.dev.dependencies]` for a list of development dependencies.
+Development dependencies are by default not shipped with distributed versions of the code for this project (for example, distributed code on [PyPI](https://pypi.org/)).
+Just the same, we strongly recommend validating included dependencies and potential vulnerabilities for your environment as well as relevant policy requirements.


### PR DESCRIPTION
This PR adds a [default security community health file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for Cytomining projects. This work might address aspects originally raised in #5.

Sidenote: the Pycytominer security tab isn't yet enabled. It might be that we could open one security reporting tab (for example, within this repo) to report any/all security issues. I could also see how this could get equally unwieldy. Interested in what you think!

Thanks for any thoughts and feedback you may have!